### PR TITLE
feat: add minimal note app

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,1 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+<title>Notes</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:wght@400&display=swap" rel="stylesheet">
+<style>
+  :root { --accent:#007AFF; }
+  *,*::before,*::after{box-sizing:border-box;-webkit-tap-highlight-color:transparent;}
+  body{
+    margin:0; background:#F9F5EC; font-family:'Inter',sans-serif; color:#222;
+    height:calc(var(--vh,1vh)*100); display:flex; flex-direction:column;
+    overflow:hidden;
+  }
+  main{
+    flex:1; overflow-y:auto; padding:24px; padding-bottom:120px; display:flex; flex-direction:column; gap:16px;
+  }
+  .note{
+    position:relative; background:rgba(255,255,255,0.7); backdrop-filter:blur(10px);
+    border-radius:24px; padding:16px 40px 16px 16px; min-height:60px;
+    box-shadow:0 2px 4px rgba(0,0,0,0.05); transition:transform .2s ease,opacity .2s ease;
+    opacity:0; transform:translateY(10px); animation:fadeIn .3s ease forwards;
+  }
+  .note:focus{outline:none;}
+  .note .material-symbols-rounded{
+    position:absolute; top:12px; right:12px; font-size:20px; cursor:pointer; color:#666;
+  }
+  .note.removing{opacity:0; transform:translateY(10px);}
+  @keyframes fadeIn{to{opacity:1; transform:none;}}
+  footer{
+    position:fixed; bottom:0; left:0; width:100%; display:flex; justify-content:center; gap:12px;
+    padding:12px 16px; padding-bottom:calc(env(safe-area-inset-bottom) + 12px);
+  }
+  .search,.control{
+    height:44px; border:none; border-radius:22px; background:rgba(255,255,255,0.7);
+    backdrop-filter:blur(10px); display:flex; align-items:center; transition:transform .2s ease;
+  }
+  .search{flex:1; padding:0 16px;}
+  .search span{font-size:24px; color:#666; margin-right:8px;}
+  .search input{flex:1; border:none; background:transparent; font-size:16px; outline:none;}
+  .control{width:44px; justify-content:center; cursor:pointer;}
+  .control span{font-size:24px; color:var(--accent);}
+  .control:active,.search:active{transform:scale(0.96);}
+</style>
+</head>
+<body>
+<main id="notes"></main>
+<footer>
+  <div class="search">
+    <span class="material-symbols-rounded">search</span>
+    <input id="searchInput" type="search" placeholder="Search">
+  </div>
+  <button id="add" class="control"><span class="material-symbols-rounded">add</span></button>
+</footer>
+<script>
+(function(){
+  const notesEl=document.getElementById('notes');
+  const search=document.getElementById('searchInput');
+  const addBtn=document.getElementById('add');
 
+  function setVh(){document.documentElement.style.setProperty('--vh', window.innerHeight*0.01+'px');}
+  window.addEventListener('resize',setVh); setVh();
+
+  function save(){
+    const data=[...notesEl.querySelectorAll('.note')].map(n=>n.innerText.trim());
+    localStorage.setItem('notes',JSON.stringify(data));
+  }
+  function addNote(text=''){
+    const note=document.createElement('div');
+    note.className='note'; note.contentEditable=true; note.spellcheck=false; note.innerText=text;
+    const del=document.createElement('span');
+    del.className='material-symbols-rounded'; del.textContent='close';
+    del.onclick=()=>{note.classList.add('removing'); setTimeout(()=>{note.remove(); save();},200);};
+    note.oninput=save; note.appendChild(del); notesEl.prepend(note); note.focus();
+  }
+  addBtn.onclick=()=>addNote();
+  search.oninput=e=>{
+    const term=e.target.value.toLowerCase();
+    notesEl.querySelectorAll('.note').forEach(n=>{n.style.display=n.innerText.toLowerCase().includes(term)?'block':'none';});
+  };
+  (function load(){(JSON.parse(localStorage.getItem('notes')||'[]')).forEach(addNote);})();
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement single-file mobile note taking app with iOS-style controls
- add bottom search and add-note pills with Material icons
- persist notes locally and enable search filtering

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c189ae8cbc8322a166519268f0d529