### PR TITLE
Create responsive note-taking app

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,1 +1,59 @@
-
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, user-scalable=no">
+<title>Notes</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@24,700,1,0&display=swap" rel="stylesheet">
+<style>
+:root{--bg:#F9F5EC;--radius:22px;}
+*{box-sizing:border-box;margin:0;padding:0;}
+body{font-family:'Inter',sans-serif;background:var(--bg);color:#000;min-height:100vh;display:flex;flex-direction:column;}
+.material-symbols-rounded{font-variation-settings:'FILL' 1,'wght' 700,'GRAD' 0,'opsz' 24;}
+#notes{list-style:none;padding:80px 16px calc(120px + env(safe-area-inset-bottom));display:flex;flex-direction:column;gap:12px;}
+.note{background:#fff;border-radius:16px;padding:16px 44px 16px 16px;position:relative;}
+.note button{position:absolute;top:8px;right:8px;width:28px;height:28px;border:none;background:transparent;display:flex;align-items:center;justify-content:center;}
+.nav{position:fixed;left:0;right:0;bottom:calc(env(safe-area-inset-bottom) + 8px);display:flex;justify-content:center;gap:12px;padding:0 16px;}
+.nav .pill,.nav .search{height:44px;border-radius:var(--radius);display:flex;align-items:center;background:rgba(255,255,255,0.8);backdrop-filter:blur(10px);box-shadow:0 2px 4px rgba(0,0,0,0.1);}
+.nav .pill{width:44px;border:none;justify-content:center;}
+.nav .search{padding:0 12px;width:60vw;max-width:300px;}
+.nav .search span{margin-right:8px;}
+.nav .search input{border:none;outline:none;background:transparent;flex:1;font:inherit;}
+.modal{position:fixed;inset:0;background:rgba(0,0,0,0.1);backdrop-filter:blur(6px);display:flex;flex-direction:column;opacity:0;pointer-events:none;transition:opacity .2s ease;}
+.modal.show{opacity:1;pointer-events:auto;}
+.editor{background:var(--bg);margin:auto;width:90%;height:70%;border-radius:16px;display:flex;flex-direction:column;overflow:hidden;transform:translateY(20px);transition:transform .2s ease;}
+.modal.show .editor{transform:translateY(0);}
+header{display:flex;justify-content:space-between;align-items:center;padding:8px 12px;}
+header button{width:32px;height:32px;border:none;background:transparent;display:flex;align-items:center;justify-content:center;}
+textarea{flex:1;border:none;padding:12px;font:inherit;background:transparent;outline:none;resize:none;}
+</style>
+</head>
+<body>
+<ul id="notes"></ul>
+<nav class="nav">
+  <div class="search"><span class="material-symbols-rounded">search</span><input id="search" placeholder="Search"></div>
+  <button class="pill" id="add"><span class="material-symbols-rounded">add</span></button>
+</nav>
+<div class="modal" id="modal">
+  <div class="editor">
+    <header>
+      <button id="close"><span class="material-symbols-rounded">close</span></button>
+      <button id="save"><span class="material-symbols-rounded">check</span></button>
+    </header>
+    <textarea id="text"></textarea>
+  </div>
+</div>
+<script>
+function setVH(){document.documentElement.style.setProperty('--vh',`${window.innerHeight*0.01}px`);}setVH();window.addEventListener('resize',setVH);
+let notes=JSON.parse(localStorage.getItem('notes')||'[]');const list=document.getElementById('notes');const modal=document.getElementById('modal');const text=document.getElementById('text');let editIndex=null;
+function render(){list.innerHTML='';notes.forEach((n,i)=>{const li=document.createElement('li');li.className='note';li.textContent=n;const del=document.createElement('button');del.innerHTML='<span class="material-symbols-rounded">close</span>';del.onclick=e=>{e.stopPropagation();notes.splice(i,1);save();};li.appendChild(del);li.onclick=()=>{editIndex=i;openEditor(n);};list.appendChild(li);});}
+function save(){localStorage.setItem('notes',JSON.stringify(notes));render();}
+function openEditor(v=''){text.value=v;modal.classList.add('show');text.focus();}
+function closeEditor(){modal.classList.remove('show');editIndex=null;}
+document.getElementById('add').onclick=()=>openEditor();document.getElementById('close').onclick=closeEditor;document.getElementById('save').onclick=()=>{const v=text.value.trim();if(v){if(editIndex!=null)notes[editIndex]=v;else notes.push(v);save();}closeEditor();};document.getElementById('search').addEventListener('input',e=>{const q=e.target.value.toLowerCase();[...list.children].forEach(li=>{li.style.display=li.textContent.toLowerCase().includes(q)?'':'none';});});render();
+</script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -29,6 +29,8 @@ body{font-family:'Inter',sans-serif;background:var(--bg);color:#000;min-height:1
 header{display:flex;justify-content:space-between;align-items:center;padding:8px 12px;}
 header button{width:32px;height:32px;border:none;background:transparent;display:flex;align-items:center;justify-content:center;}
 textarea{flex:1;border:none;padding:12px;font:inherit;background:transparent;outline:none;resize:none;}
+@keyframes bounce{0%,100%{transform:scale(1);}50%{transform:scale(0.92);}70%{transform:scale(1.04);}}
+.bounce{animation:bounce .3s cubic-bezier(.34,1.56,.64,1);}
 </style>
 </head>
 <body>
@@ -49,11 +51,12 @@ textarea{flex:1;border:none;padding:12px;font:inherit;background:transparent;out
 <script>
 function setVH(){document.documentElement.style.setProperty('--vh',`${window.innerHeight*0.01}px`);}setVH();window.addEventListener('resize',setVH);
 let notes=JSON.parse(localStorage.getItem('notes')||'[]');const list=document.getElementById('notes');const modal=document.getElementById('modal');const text=document.getElementById('text');let editIndex=null;
-function render(){list.innerHTML='';notes.forEach((n,i)=>{const li=document.createElement('li');li.className='note';li.textContent=n;const del=document.createElement('button');del.innerHTML='<span class="material-symbols-rounded">close</span>';del.onclick=e=>{e.stopPropagation();notes.splice(i,1);save();};li.appendChild(del);li.onclick=()=>{editIndex=i;openEditor(n);};list.appendChild(li);});}
+function bounce(el){el.classList.add('bounce');el.addEventListener('animationend',()=>el.classList.remove('bounce'),{once:true});}
+function render(){list.innerHTML='';notes.forEach((n,i)=>{const li=document.createElement('li');li.className='note';li.textContent=n;const del=document.createElement('button');del.innerHTML='<span class="material-symbols-rounded">close</span>';del.onclick=e=>{e.stopPropagation();bounce(e.currentTarget);notes.splice(i,1);save();};li.appendChild(del);li.onclick=()=>{bounce(li);editIndex=i;openEditor(n);};list.appendChild(li);});}
 function save(){localStorage.setItem('notes',JSON.stringify(notes));render();}
 function openEditor(v=''){text.value=v;modal.classList.add('show');text.focus();}
 function closeEditor(){modal.classList.remove('show');editIndex=null;}
-document.getElementById('add').onclick=()=>openEditor();document.getElementById('close').onclick=closeEditor;document.getElementById('save').onclick=()=>{const v=text.value.trim();if(v){if(editIndex!=null)notes[editIndex]=v;else notes.push(v);save();}closeEditor();};document.getElementById('search').addEventListener('input',e=>{const q=e.target.value.toLowerCase();[...list.children].forEach(li=>{li.style.display=li.textContent.toLowerCase().includes(q)?'':'none';});});render();
+document.getElementById('add').onclick=e=>{bounce(e.currentTarget);openEditor();};document.getElementById('close').onclick=e=>{bounce(e.currentTarget);closeEditor();};document.getElementById('save').onclick=e=>{bounce(e.currentTarget);const v=text.value.trim();if(v){if(editIndex!=null)notes[editIndex]=v;else notes.push(v);save();}closeEditor();};document.getElementById('search').addEventListener('input',e=>{const q=e.target.value.toLowerCase();[...list.children].forEach(li=>{li.style.display=li.textContent.toLowerCase().includes(q)?'':'none';});});render();
 </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -14,8 +14,10 @@
 body{font-family:'Inter',sans-serif;background:var(--bg);color:#000;min-height:100vh;display:flex;flex-direction:column;}
 .material-symbols-rounded{font-variation-settings:'FILL' 1,'wght' 700,'GRAD' 0,'opsz' 24;}
 #notes{list-style:none;padding:80px 16px calc(120px + env(safe-area-inset-bottom));display:flex;flex-direction:column;gap:12px;}
-.note{background:#fff;border-radius:16px;padding:16px 44px 16px 16px;position:relative;}
-.note button{position:absolute;top:8px;right:8px;width:28px;height:28px;border:none;background:transparent;display:flex;align-items:center;justify-content:center;}
+.note{background:#fff;border-radius:16px;padding:16px 44px;position:relative;}
+.note button{position:absolute;top:8px;width:28px;height:28px;border:none;background:transparent;display:flex;align-items:center;justify-content:center;}
+.note .pin{left:8px;}
+.note .del{right:8px;}
 .nav{position:fixed;left:0;right:0;bottom:calc(env(safe-area-inset-bottom) + 8px);display:flex;justify-content:center;gap:12px;padding:0 16px;}
 .nav .pill,.nav .search{height:44px;border-radius:var(--radius);display:flex;align-items:center;background:rgba(255,255,255,0.8);backdrop-filter:blur(10px);box-shadow:0 2px 4px rgba(0,0,0,0.1);}
 .nav .pill{width:44px;border:none;justify-content:center;}
@@ -36,6 +38,7 @@ textarea{flex:1;border:none;padding:12px;font:inherit;background:transparent;out
 <body>
 <ul id="notes"></ul>
 <nav class="nav">
+  <button class="pill" id="clear"><span class="material-symbols-rounded">delete</span></button>
   <div class="search"><span class="material-symbols-rounded">search</span><input id="search" placeholder="Search"></div>
   <button class="pill" id="add"><span class="material-symbols-rounded">add</span></button>
 </nav>
@@ -50,13 +53,13 @@ textarea{flex:1;border:none;padding:12px;font:inherit;background:transparent;out
 </div>
 <script>
 function setVH(){document.documentElement.style.setProperty('--vh',`${window.innerHeight*0.01}px`);}setVH();window.addEventListener('resize',setVH);
-let notes=JSON.parse(localStorage.getItem('notes')||'[]');const list=document.getElementById('notes');const modal=document.getElementById('modal');const text=document.getElementById('text');const search=document.getElementById('search');let editIndex=null;
+let notes=JSON.parse(localStorage.getItem('notes')||'[]').map(n=>typeof n==='string'?{text:n,pinned:false}:n);const list=document.getElementById('notes');const modal=document.getElementById('modal');const text=document.getElementById('text');const search=document.getElementById('search');let editIndex=null;
 function bounce(el){el.classList.add('bounce');el.addEventListener('animationend',()=>el.classList.remove('bounce'),{once:true});}
-function render(){list.innerHTML='';notes.forEach((n,i)=>{const li=document.createElement('li');li.className='note';li.textContent=n;const del=document.createElement('button');del.innerHTML='<span class="material-symbols-rounded">close</span>';del.onclick=e=>{e.stopPropagation();bounce(e.currentTarget);notes.splice(i,1);save();};li.appendChild(del);li.onclick=()=>{bounce(li);editIndex=i;openEditor(n);};list.appendChild(li);});}
+function render(){notes.sort((a,b)=>b.pinned-a.pinned);list.innerHTML='';notes.forEach((n,i)=>{const li=document.createElement('li');li.className='note';li.dataset.i=i;const t=document.createElement('div');t.textContent=n.text;li.appendChild(t);const pin=document.createElement('button');pin.className='pin';pin.innerHTML=`<span class="material-symbols-rounded">${n.pinned?'star':'star_border'}</span>`;pin.onclick=e=>{e.stopPropagation();bounce(e.currentTarget);notes[i].pinned=!notes[i].pinned;save();};li.appendChild(pin);const del=document.createElement('button');del.className='del';del.innerHTML='<span class="material-symbols-rounded">close</span>';del.onclick=e=>{e.stopPropagation();bounce(e.currentTarget);notes.splice(i,1);save();};li.appendChild(del);li.onclick=()=>{bounce(li);editIndex=i;openEditor(n.text);};list.appendChild(li);});const q=search.value.toLowerCase();[...list.children].forEach(li=>{li.style.display=notes[li.dataset.i].text.toLowerCase().includes(q)?'':'none';});}
 function save(){localStorage.setItem('notes',JSON.stringify(notes));render();}
 function openEditor(v=''){text.value=v;modal.classList.add('show');text.focus();}
 function closeEditor(){modal.classList.remove('show');editIndex=null;}
-document.getElementById('add').onclick=e=>{bounce(e.currentTarget);openEditor();};document.getElementById('close').onclick=e=>{bounce(e.currentTarget);closeEditor();};document.getElementById('save').onclick=e=>{bounce(e.currentTarget);const v=text.value.trim();if(v){if(editIndex!=null)notes[editIndex]=v;else notes.push(v);save();}closeEditor();};search.parentElement.addEventListener('click',e=>bounce(e.currentTarget));search.addEventListener('input',e=>{const q=e.target.value.toLowerCase();[...list.children].forEach(li=>{li.style.display=li.textContent.toLowerCase().includes(q)?'':'none';});});render();
+document.getElementById('add').onclick=e=>{bounce(e.currentTarget);openEditor();};document.getElementById('clear').onclick=e=>{bounce(e.currentTarget);if(notes.length&&confirm('Clear all?')){notes=[];save();}};document.getElementById('close').onclick=e=>{bounce(e.currentTarget);closeEditor();};document.getElementById('save').onclick=e=>{bounce(e.currentTarget);const v=text.value.trim();if(v){if(editIndex!=null)notes[editIndex].text=v;else notes.push({text:v,pinned:false});save();}closeEditor();};search.parentElement.addEventListener('click',e=>bounce(e.currentTarget));search.addEventListener('input',e=>{const q=e.target.value.toLowerCase();[...list.children].forEach(li=>{li.style.display=notes[li.dataset.i].text.toLowerCase().includes(q)?'':'none';});});render();
 </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -50,13 +50,13 @@ textarea{flex:1;border:none;padding:12px;font:inherit;background:transparent;out
 </div>
 <script>
 function setVH(){document.documentElement.style.setProperty('--vh',`${window.innerHeight*0.01}px`);}setVH();window.addEventListener('resize',setVH);
-let notes=JSON.parse(localStorage.getItem('notes')||'[]');const list=document.getElementById('notes');const modal=document.getElementById('modal');const text=document.getElementById('text');let editIndex=null;
+let notes=JSON.parse(localStorage.getItem('notes')||'[]');const list=document.getElementById('notes');const modal=document.getElementById('modal');const text=document.getElementById('text');const search=document.getElementById('search');let editIndex=null;
 function bounce(el){el.classList.add('bounce');el.addEventListener('animationend',()=>el.classList.remove('bounce'),{once:true});}
 function render(){list.innerHTML='';notes.forEach((n,i)=>{const li=document.createElement('li');li.className='note';li.textContent=n;const del=document.createElement('button');del.innerHTML='<span class="material-symbols-rounded">close</span>';del.onclick=e=>{e.stopPropagation();bounce(e.currentTarget);notes.splice(i,1);save();};li.appendChild(del);li.onclick=()=>{bounce(li);editIndex=i;openEditor(n);};list.appendChild(li);});}
 function save(){localStorage.setItem('notes',JSON.stringify(notes));render();}
 function openEditor(v=''){text.value=v;modal.classList.add('show');text.focus();}
 function closeEditor(){modal.classList.remove('show');editIndex=null;}
-document.getElementById('add').onclick=e=>{bounce(e.currentTarget);openEditor();};document.getElementById('close').onclick=e=>{bounce(e.currentTarget);closeEditor();};document.getElementById('save').onclick=e=>{bounce(e.currentTarget);const v=text.value.trim();if(v){if(editIndex!=null)notes[editIndex]=v;else notes.push(v);save();}closeEditor();};document.getElementById('search').addEventListener('input',e=>{const q=e.target.value.toLowerCase();[...list.children].forEach(li=>{li.style.display=li.textContent.toLowerCase().includes(q)?'':'none';});});render();
+document.getElementById('add').onclick=e=>{bounce(e.currentTarget);openEditor();};document.getElementById('close').onclick=e=>{bounce(e.currentTarget);closeEditor();};document.getElementById('save').onclick=e=>{bounce(e.currentTarget);const v=text.value.trim();if(v){if(editIndex!=null)notes[editIndex]=v;else notes.push(v);save();}closeEditor();};search.parentElement.addEventListener('click',e=>bounce(e.currentTarget));search.addEventListener('input',e=>{const q=e.target.value.toLowerCase();[...list.children].forEach(li=>{li.style.display=li.textContent.toLowerCase().includes(q)?'':'none';});});render();
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Build minimal mobile note-taking web app with off-white palette and bottom-centered controls
- Include Google Fonts typography and Material Symbols icons with preconnect hints
- Add search, add, delete, and modal editing with smooth transitions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c18a7767808322a71fe972c32fb7a7