### PR TITLE
Add minimal infinite-scroll image feed

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,17 +3,17 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
-<title>Reels</title>
+<title>Scroll</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
 <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@24,400,0,0&display=swap" rel="stylesheet">
 <style>
 :root{--vh:1vh;}
-html,body{height:100%;margin:0;background:#F9F5EC;font-family:'Inter',sans-serif;overflow:hidden;}
-main{height:calc(var(--vh) * 100);overflow-y:auto;scroll-snap-type:y mandatory;scroll-behavior:smooth;-webkit-overflow-scrolling:touch;touch-action:pan-y;}
-section{height:calc(var(--vh) * 100);scroll-snap-align:start;position:relative;display:flex;align-items:center;justify-content:center;animation:fade .5s ease;}
-video{width:100%;height:100%;object-fit:cover;}
+html,body{height:100%;margin:0;background:#F9F5EC;font-family:'Inter',sans-serif;overflow:hidden;-webkit-user-select:none;user-select:none;}
+main{height:calc(var(--vh)*100);overflow-y:auto;scroll-snap-type:y mandatory;-webkit-overflow-scrolling:touch;touch-action:pan-y;scroll-behavior:smooth;}
+section{height:calc(var(--vh)*100);scroll-snap-align:start;position:relative;display:flex;align-items:center;justify-content:center;animation:fade .5s ease;}
+img{width:100%;height:100%;object-fit:cover;opacity:0;transition:opacity .4s ease;}
 nav{position:fixed;left:50%;bottom:calc(env(safe-area-inset-bottom) + 16px);transform:translateX(-50%);display:flex;gap:12px;z-index:10;}
 .pill{width:52px;height:52px;border:none;border-radius:26px;background:rgba(255,255,255,.6);backdrop-filter:blur(20px);display:flex;align-items:center;justify-content:center;padding:0;}
 .pill span{font-size:28px;line-height:1;}
@@ -29,29 +29,23 @@ nav{position:fixed;left:50%;bottom:calc(env(safe-area-inset-bottom) + 16px);tran
 </nav>
 <script>
 const feed=document.getElementById('feed');
-const videos=[
-  'https://assets.mixkit.co/videos/preview/mixkit-perfection-of-geometry-307.mp4',
-  'https://assets.mixkit.co/videos/preview/mixkit-aerial-shot-of-a-city-12.mp4',
-  'https://assets.mixkit.co/videos/preview/mixkit-open-car-sunroof-view-109.mp4'
-];
 let i=0;
 function setVH(){document.documentElement.style.setProperty('--vh', (window.innerHeight*0.01)+'px');}
 setVH(); addEventListener('resize', setVH);
-function addVideo(){
-  const src=videos[i%videos.length]; i++;
+function addImage(){
+  const seed=Date.now()+i++;
   const sec=document.createElement('section');
-  const vid=document.createElement('video');
-  Object.assign(vid,{src,autoplay:true,loop:true,muted:true,playsInline:true});
-  sec.appendChild(vid); feed.appendChild(sec);
-  observer.observe(vid);
+  const img=new Image();
+  img.src=`https://picsum.photos/seed/${seed}/1080/1920`;
+  img.alt='';
+  img.onload=()=>{img.style.opacity='1';};
+  sec.appendChild(img);
+  feed.appendChild(sec);
 }
-const observer=new IntersectionObserver(entries=>{
-  entries.forEach(e=>{e.isIntersecting?e.target.play():e.target.pause();});
-},{threshold:0.6});
 feed.addEventListener('scroll',()=>{
-  if(feed.scrollTop + feed.clientHeight >= feed.scrollHeight-2) addVideo();
+  if(feed.scrollTop + feed.clientHeight >= feed.scrollHeight-2) addImage();
 });
-for(let j=0;j<3;j++) addVideo();
+for(let j=0;j<3;j++) addImage();
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Build off-white mobile feed with scroll-snapping for smooth, locking swipes
- Fetch random images from open source Picsum pool and load more on scroll
- Center pill-shaped navigation buttons inside iOS safe area and load Google fonts/icons reliably

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e1e779ac83229d36298acec8654e