### PR TITLE
feat: add mobile calendar app

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,115 +2,200 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, user-scalable=no">
-<title>Scroll</title>
+<meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover,user-scalable=no">
+<title>Calendar</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
 <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@24,400,0,0&display=swap" rel="stylesheet">
 <style>
-:root{--vh:1vh;}
-html,body{height:100%;margin:0;background:#F9F5EC;font-family:'Inter',sans-serif;overflow:hidden;-webkit-user-select:none;user-select:none;}
-main{height:calc(var(--vh)*100);overflow-y:auto;scroll-snap-type:y mandatory;-webkit-overflow-scrolling:touch;touch-action:pan-y;scroll-behavior:smooth;}
-section{height:calc(var(--vh)*100);scroll-snap-align:start;position:relative;display:flex;align-items:center;justify-content:center;animation:fade .5s ease;}
-img{width:100%;height:100%;object-fit:cover;opacity:0;transition:opacity .4s ease;}
+:root{--vh:1vh;--day:40px;}
+*{box-sizing:border-box;margin:0;padding:0;}
+html,body{height:100%;background:#F9F5EC;font-family:'Inter',sans-serif;-webkit-user-select:none;user-select:none;}
+main{height:calc(var(--vh)*100);display:flex;flex-direction:column;}
+header{display:flex;align-items:center;justify-content:space-between;padding:16px;font-weight:600;}
+header .material-symbols-rounded{font-size:24px;}
+#weekdays{display:grid;grid-template-columns:repeat(7,1fr);text-align:center;font-size:14px;opacity:.6;padding:0 8px;}
+#calendar{display:grid;grid-template-columns:repeat(7,var(--day));grid-auto-rows:var(--day);padding:8px;gap:4px;justify-content:center;width:100%;}
+.day{position:relative;display:flex;align-items:center;justify-content:center;width:var(--day);height:var(--day);border-radius:12px;}
+.day span{position:relative;z-index:1;}
+.day.today{background:rgba(0,0,0,.05);}
+.day .dot{position:absolute;bottom:6px;width:6px;height:6px;border-radius:3px;background:#007AFF;}
 nav{position:fixed;left:50%;bottom:calc(env(safe-area-inset-bottom) + 16px);transform:translateX(-50%);display:flex;gap:12px;z-index:10;}
-.pill{width:64px;height:40px;border:none;border-radius:20px;background:rgba(255,255,255,.6);backdrop-filter:blur(20px);display:flex;align-items:center;justify-content:center;padding:0;color:#222;}
-.pill span{font-size:24px;line-height:1;font-variation-settings:'FILL' 1,'wght' 400,'GRAD' 0,'opsz' 24;}
+.pill{width:64px;height:40px;border:none;border-radius:20px;background:rgba(255,255,255,.6);backdrop-filter:blur(20px);display:flex;align-items:center;justify-content:center;padding:0;color:#222;cursor:pointer;}
+.pill span{font-size:24px;line-height:1;}
+dialog{border:none;border-radius:16px;padding:20px;max-width:90%;background:rgba(255,255,255,.9);backdrop-filter:blur(20px);position:fixed;top:50%;left:50%;transform:translate(-50%,-50%) scale(.95);opacity:0;transition:opacity .2s ease,transform .2s ease;}
+dialog.open{opacity:1;transform:translate(-50%,-50%) scale(1);}
+dialog::backdrop{background:rgba(0,0,0,.1);}
+dialog h2{font-size:18px;margin-bottom:12px;}
+dialog form{display:flex;gap:8px;margin-top:12px;}
+dialog input{flex:1;border:none;border-radius:20px;padding:8px 12px;background:rgba(255,255,255,.6);}
+dialog button{border:none;border-radius:20px;padding:8px 12px;background:rgba(255,255,255,.6);}
+#eventList{list-style:none;max-height:200px;overflow:auto;padding:0;}
+#eventList li{display:flex;justify-content:space-between;align-items:center;padding:4px 0;}
+#eventList li span:first-child{flex:1;}
+#eventList li button{background:none;padding:0;margin:0;border:none;}
+#eventList li button span{font-size:20px;}
+#searchResults{list-style:none;max-height:200px;overflow:auto;padding:0;margin-top:8px;}
+.fade{animation:fade .3s ease;}
 @keyframes fade{from{opacity:0;transform:scale(.97);}to{opacity:1;transform:scale(1);}}
-dialog{border:none;border-radius:12px;padding:20px;max-width:90%;background:rgba(255,255,255,.9);backdrop-filter:blur(20px);}
-dialog form{display:flex;gap:8px;}
-dialog input,dialog button{border:none;border-radius:20px;background:rgba(255,255,255,.6);backdrop-filter:blur(20px);padding:8px 12px;color:#222;}
-dialog input{flex:1;}
-dialog button{cursor:pointer;}
-body.dark{background:#222;color:#eee;}
-body.dark nav .pill,body.dark dialog input,body.dark dialog button{background:rgba(0,0,0,.6);color:#eee;}
-body.dark dialog{background:rgba(34,34,34,.9);}
 </style>
 </head>
 <body>
-<main id="feed"></main>
- <nav>
-   <button id="homeBtn" class="pill"><span class="material-symbols-rounded">home</span></button>
-   <button id="searchBtn" class="pill"><span class="material-symbols-rounded">search</span></button>
-   <button id="profileBtn" class="pill"><span class="material-symbols-rounded">person</span></button>
-   <button id="themeBtn" class="pill"><span class="material-symbols-rounded">dark_mode</span></button>
- </nav>
-<dialog id="searchDialog">
-  <form id="searchForm" method="dialog">
-    <input id="searchInput" type="text" placeholder="Image seed" />
-    <button type="submit">Add</button>
-    <button type="button" id="searchCancel">Cancel</button>
-  </form>
+<main>
+<header>
+<button id="prev" class="pill"><span class="material-symbols-rounded">chevron_left</span></button>
+<div id="month"></div>
+<button id="next" class="pill"><span class="material-symbols-rounded">chevron_right</span></button>
+</header>
+<div id="weekdays"></div>
+<div id="calendar"></div>
+</main>
+<nav>
+<button id="searchBtn" class="pill"><span class="material-symbols-rounded">search</span></button>
+<button id="addBtn" class="pill"><span class="material-symbols-rounded">add</span></button>
+<button id="todayBtn" class="pill"><span class="material-symbols-rounded">today</span></button>
+</nav>
+<dialog id="eventDialog">
+<h2 id="eventDate"></h2>
+<ul id="eventList"></ul>
+<form id="eventForm" method="dialog">
+<input id="eventInput" type="text" placeholder="Event">
+<button type="submit"><span class="material-symbols-rounded">add</span></button>
+</form>
 </dialog>
-<dialog id="profileDialog">
-  <p>Profile coming soon…</p>
-  <form method="dialog">
-    <button>Close</button>
-  </form>
+<dialog id="searchDialog">
+<form id="searchForm" method="dialog">
+<input id="searchInput" type="text" placeholder="Search">
+<button type="submit"><span class="material-symbols-rounded">search</span></button>
+</form>
+<ul id="searchResults"></ul>
 </dialog>
 <script>
-const feed=document.getElementById('feed');
-let i=0;
-function setVH(){document.documentElement.style.setProperty('--vh', (window.innerHeight*0.01)+'px');}
-setVH(); addEventListener('resize', setVH);
-function addImage(seed=Date.now()+i++){
-  const sec=document.createElement('section');
-  const img=new Image();
-  img.src=`https://picsum.photos/seed/${seed}/1080/1920`;
-  img.alt='';
-  img.onload=()=>{img.style.opacity='1';};
-  sec.appendChild(img);
-  feed.appendChild(sec);
-}
-feed.addEventListener('scroll',()=>{
-  if(feed.scrollTop + feed.clientHeight >= feed.scrollHeight-2) addImage();
-});
-for(let j=0;j<3;j++) addImage();
-
-const homeBtn=document.getElementById('homeBtn');
-const searchBtn=document.getElementById('searchBtn');
-const profileBtn=document.getElementById('profileBtn');
-const themeBtn=document.getElementById('themeBtn');
+const state={date:new Date(),events:JSON.parse(localStorage.getItem('events')||'{}')};
+const monthEl=document.getElementById('month');
+const weekdaysEl=document.getElementById('weekdays');
+const calendarEl=document.getElementById('calendar');
+const headerEl=document.querySelector('header');
+const nav=document.querySelector('nav');
+const eventDialog=document.getElementById('eventDialog');
+const eventDateEl=document.getElementById('eventDate');
+const eventList=document.getElementById('eventList');
+const eventForm=document.getElementById('eventForm');
+const eventInput=document.getElementById('eventInput');
 const searchDialog=document.getElementById('searchDialog');
 const searchForm=document.getElementById('searchForm');
 const searchInput=document.getElementById('searchInput');
-const searchCancel=document.getElementById('searchCancel');
-const profileDialog=document.getElementById('profileDialog');
+const searchResults=document.getElementById('searchResults');
 
-homeBtn.addEventListener('click',()=>{
-  feed.scrollTo({top:0,behavior:'smooth'});
-});
+function setVH(){document.documentElement.style.setProperty('--vh',(window.innerHeight*0.01)+'px');}
+function layout(){
+ const gap=4,pad=16;
+ const availW=window.innerWidth-pad;
+ const maxW=Math.floor((availW-gap*6)/7);
+ const headerH=headerEl.offsetHeight;
+ const weekdaysH=weekdaysEl.offsetHeight;
+ const navH=nav.offsetHeight+16;
+ const availH=window.innerHeight-headerH-weekdaysH-navH-pad;
+ const maxH=Math.floor((availH-gap*5)/6);
+ const size=Math.max(0,Math.min(maxW,maxH));
+ document.documentElement.style.setProperty('--day',size+'px');
+calendarEl.style.height=(size*6+gap*5)+'px';
+}
+ setVH();addEventListener('resize',()=>{setVH();layout();});
 
-searchBtn.addEventListener('click',()=>{
-  searchInput.value='';
-  searchDialog.showModal();
-  searchInput.focus();
-});
+function showDialog(d){d.showModal();requestAnimationFrame(()=>d.classList.add('open'));}
+function hideDialog(d){d.classList.remove('open');d.addEventListener('transitionend',()=>d.close(),{once:true});}
 
-searchForm.addEventListener('submit',e=>{
-  e.preventDefault();
-  const seed=searchInput.value.trim();
-  if(seed){
-    addImage(seed);
-    searchDialog.close();
-  }
-});
+const weekdays=['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
+weekdaysEl.innerHTML=weekdays.map(d=>`<div>${d}</div>`).join('');
 
-searchCancel.addEventListener('click',()=>{
-  searchDialog.close();
+function renderCalendar(){
+const year=state.date.getFullYear();
+const month=state.date.getMonth();
+monthEl.textContent=state.date.toLocaleDateString(undefined,{month:'long',year:'numeric'});
+calendarEl.innerHTML='';
+const first=new Date(year,month,1).getDay();
+const days=new Date(year,month+1,0).getDate();
+for(let i=0;i<first;i++) calendarEl.appendChild(document.createElement('div'));
+for(let d=1;d<=days;d++){
+ const dateStr=`${year}-${String(month+1).padStart(2,'0')}-${String(d).padStart(2,'0')}`;
+ const cell=document.createElement('div');
+ cell.className='day fade';
+ if(dateStr===todayStr()) cell.classList.add('today');
+ cell.innerHTML=`<span>${d}</span>`;
+ if(state.events[dateStr]){const dot=document.createElement('div');dot.className='dot';cell.appendChild(dot);}
+ cell.onclick=()=>openEvents(dateStr);
+ calendarEl.appendChild(cell);
+}
+ layout();
+}
+function todayStr(){
+const t=new Date();
+return `${t.getFullYear()}-${String(t.getMonth()+1).padStart(2,'0')}-${String(t.getDate()).padStart(2,'0')}`;
+}
+function openEvents(dateStr){
+eventDateEl.textContent=new Date(dateStr).toLocaleDateString(undefined,{weekday:'short',month:'short',day:'numeric'});
+eventDialog.returnValue='';
+showDialog(eventDialog);
+renderEvents(dateStr);
+eventForm.onsubmit=e=>{
+ e.preventDefault();
+ const text=eventInput.value.trim();
+ if(!text) return;
+ (state.events[dateStr]=state.events[dateStr]||[]).push(text);
+ localStorage.setItem('events',JSON.stringify(state.events));
+ eventInput.value='';
+ renderEvents(dateStr);
+ renderCalendar();
+};
+eventDialog.onclick=e=>{if(e.target===eventDialog)hideDialog(eventDialog);};
+eventDialog.addEventListener('cancel',e=>{e.preventDefault();hideDialog(eventDialog);});
+}
+function renderEvents(dateStr){
+eventInput.value='';
+eventList.innerHTML='';
+(state.events[dateStr]||[]).forEach((ev,i)=>{
+ const li=document.createElement('li');
+ li.innerHTML=`<span>${ev}</span><button data-i="${i}"><span class="material-symbols-rounded">close</span></button>`;
+ eventList.appendChild(li);
 });
+eventList.querySelectorAll('button').forEach(btn=>btn.onclick=()=>{
+ const i=btn.getAttribute('data-i');
+ state.events[dateStr].splice(i,1);
+ if(!state.events[dateStr].length) delete state.events[dateStr];
+ localStorage.setItem('events',JSON.stringify(state.events));
+ renderEvents(dateStr);
+ renderCalendar();
+});
+}
 
-profileBtn.addEventListener('click',()=>{
-  profileDialog.showModal();
-});
-
-let dark=false;
-themeBtn.addEventListener('click',()=>{
-  dark=!dark;
-  document.body.classList.toggle('dark',dark);
-  themeBtn.querySelector('span').textContent=dark?'light_mode':'dark_mode';
-});
+document.getElementById('prev').onclick=()=>{state.date.setMonth(state.date.getMonth()-1);renderCalendar();};
+document.getElementById('next').onclick=()=>{state.date.setMonth(state.date.getMonth()+1);renderCalendar();};
+document.getElementById('todayBtn').onclick=()=>{state.date=new Date();renderCalendar();};
+document.getElementById('addBtn').onclick=()=>{
+ const ds=todayStr();
+ openEvents(ds);
+};
+document.getElementById('searchBtn').onclick=()=>{searchInput.value='';searchResults.innerHTML='';showDialog(searchDialog);searchInput.focus();};
+searchForm.onsubmit=e=>{
+ e.preventDefault();
+ const q=searchInput.value.trim().toLowerCase();
+ searchResults.innerHTML='';
+ if(!q) return;
+ Object.keys(state.events).forEach(date=>{
+ state.events[date].forEach(ev=>{
+ if(ev.toLowerCase().includes(q)){
+ const li=document.createElement('li');
+ li.textContent=`${new Date(date).toLocaleDateString(undefined,{month:'short',day:'numeric'})}: ${ev}`;
+ searchResults.appendChild(li);
+ }
+ });
+ });
+};
+searchDialog.onclick=e=>{if(e.target===searchDialog)hideDialog(searchDialog);};
+searchDialog.addEventListener('cancel',e=>{e.preventDefault();hideDialog(searchDialog);});
+renderCalendar();
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- build responsive calendar app with off-white iOS-style design and pill controls
- support event creation/search with local storage
- refine calendar sizing and center dialogs with smooth fade transitions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ebc4fb6083228a12af46d74c8341