### PR TITLE
Ensure calendar fits screen and dialogs fade into center

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,10 +9,10 @@
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
 <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@24,400,0,0&display=swap" rel="stylesheet">
 <style>
-:root{--vh:1vh;}
+:root{--vh:1vh;--nav-height:72px;}
 *{box-sizing:border-box;margin:0;padding:0;}
 html,body{height:100%;background:#F9F5EC;font-family:'Inter',sans-serif;-webkit-user-select:none;user-select:none;}
-main{height:calc(var(--vh)*100);display:flex;flex-direction:column;}
+main{height:calc(var(--vh)*100 - var(--nav-height));display:flex;flex-direction:column;}
 header{display:flex;align-items:center;justify-content:space-between;padding:16px;font-weight:600;}
 header .material-symbols-rounded{font-size:24px;}
 #weekdays{display:grid;grid-template-columns:repeat(7,1fr);text-align:center;font-size:14px;opacity:.6;padding:0 8px;}
@@ -24,7 +24,9 @@ header .material-symbols-rounded{font-size:24px;}
 nav{position:fixed;left:50%;bottom:calc(env(safe-area-inset-bottom) + 16px);transform:translateX(-50%);display:flex;gap:12px;z-index:10;}
 .pill{width:64px;height:40px;border:none;border-radius:20px;background:rgba(255,255,255,.6);backdrop-filter:blur(20px);display:flex;align-items:center;justify-content:center;padding:0;color:#222;cursor:pointer;}
 .pill span{font-size:24px;line-height:1;}
-dialog{border:none;border-radius:16px;padding:20px;max-width:90%;background:rgba(255,255,255,.9);backdrop-filter:blur(20px);}
+dialog{border:none;border-radius:16px;padding:20px;max-width:90%;background:rgba(255,255,255,.9);backdrop-filter:blur(20px);margin:auto;}
+dialog[open]{animation:fade .3s ease;}
+dialog::backdrop{animation:fade .3s ease;}
 dialog h2{font-size:18px;margin-bottom:12px;}
 dialog form{display:flex;gap:8px;margin-top:12px;}
 dialog input{flex:1;border:none;border-radius:20px;padding:8px 12px;background:rgba(255,255,255,.6);}


### PR DESCRIPTION
## Summary
- Prevent calendar grid from being hidden behind the bottom navigation bar
- Center dialogs and add fade-in animation for a smoother popup experience

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ef9039fc8322ae01b59706103bef