### PR TITLE
Fix calendar going off-screen by computing nav height

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,8 +85,14 @@ const searchDialog=document.getElementById('searchDialog');
 const searchForm=document.getElementById('searchForm');
 const searchInput=document.getElementById('searchInput');
 const searchResults=document.getElementById('searchResults');
+const nav=document.querySelector('nav');
 
-function setVH(){document.documentElement.style.setProperty('--vh',(window.innerHeight*0.01)+'px');}
+function setVH(){
+ document.documentElement.style.setProperty('--vh',(window.innerHeight*0.01)+'px');
+ const navRect=nav.getBoundingClientRect();
+ const navHeight=navRect.height+(window.innerHeight-navRect.bottom);
+ document.documentElement.style.setProperty('--nav-height',navHeight+'px');
+}
 setVH();addEventListener('resize',setVH);
 
 const weekdays=['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];


### PR DESCRIPTION
## Summary
- Dynamically compute navigation height to size main content and keep calendar within viewport

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f0efb42083228a4907f5c54f025e