### PR TITLE
feat: add responsive mobile weather app

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,196 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover,user-scalable=no">
+<title>Weather</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@48,400,1,0&display=swap" rel="stylesheet">
+<style>
+:root{
+ --accent:#3A6EA5;
+ --bg:#F9F5EC;
+ --radius:28px;
+ --pill-padding:12px 18px;
+ font-family:'Inter',sans-serif;
+}
+body{
+ margin:0;
+ background:var(--bg);
+ color:#222;
+ height:calc(var(--vh,1vh)*100);
+ display:flex;
+ flex-direction:column;
+ align-items:center;
+ justify-content:center;
+ text-align:center;
+ overflow:hidden;
+}
+.weather-icon .material-symbols-rounded{font-size:72px;line-height:1;display:block;}
+#wicon{font-variation-settings:'FILL' 1,'wght'400,'GRAD'0,'opsz'72;}
+#temp{font-size:64px;font-weight:600;}
+#desc,#location{font-size:16px;margin-top:4px;}
+nav{
+ position:fixed;
+ bottom:0;
+ left:50%;
+ transform:translateX(-50%);
+ display:flex;
+ gap:12px;
+ padding:calc(env(safe-area-inset-bottom) + 12px) 12px;
+ background:rgba(255,255,255,0.6);
+ backdrop-filter:blur(20px);
+ border-radius:calc(var(--radius) + env(safe-area-inset-bottom));
+}
+button{
+ background:rgba(255,255,255,0.8);
+ border:none;
+ border-radius:var(--radius);
+ padding:var(--pill-padding);
+ display:flex;
+ align-items:center;
+ gap:6px;
+ font-size:16px;
+ color:var(--accent);
+ font-weight:500;
+ cursor:pointer;
+}
+button span.material-symbols-rounded{font-size:24px;}
+#sheet{
+ position:fixed;
+ left:0;
+ right:0;
+ bottom:0;
+ transform:translateY(100%);
+ transition:transform 0.3s ease;
+ background:rgba(249,245,236,0.95);
+ backdrop-filter:blur(20px);
+ border-top-left-radius:24px;
+ border-top-right-radius:24px;
+ padding:20px 16px calc(env(safe-area-inset-bottom) + 20px);
+ display:flex;
+ flex-direction:column;
+ gap:16px;
+}
+#sheet.active{transform:translateY(0);}
+#sheet header{
+ display:flex;
+ justify-content:flex-end;
+}
+#sheet header button{
+ padding:8px;
+ border-radius:50%;
+ background:transparent;
+ color:#444;
+}
+#sheet input{
+ border:none;
+ background:#fff;
+ padding:12px 16px;
+ border-radius:var(--radius);
+ font-size:16px;
+}
+#results{display:flex;flex-direction:column;gap:8px;}
+#results button{
+ background:#fff;
+ color:#333;
+ justify-content:flex-start;
+}
+.material-symbols-rounded{font-variation-settings:'FILL' 1,'wght'400,'GRAD'0,'opsz'48;}
+.fade{transition:opacity 0.4s ease,transform 0.4s ease;}
+.fade.show{opacity:1;transform:scale(1);}
+.fade.hide{opacity:0;transform:scale(0.98);}
+</style>
+</head>
+<body>
+<div id="display" class="fade hide">
+  <div class="weather-icon"><span id="wicon" class="material-symbols-rounded">sunny</span></div>
+  <div id="temp"></div>
+  <div id="desc"></div>
+  <div id="location"></div>
+</div>
+<nav>
+  <button id="locate"><span class="material-symbols-rounded">my_location</span><span>Locate</span></button>
+  <button id="openSearch"><span class="material-symbols-rounded">search</span><span>Search</span></button>
+</nav>
+<div id="sheet">
+  <header><button id="close"><span class="material-symbols-rounded">close</span></button></header>
+  <input id="search" placeholder="City">
+  <div id="results"></div>
+</div>
+<script>
+(function(){
+ const api={
+  geo:q=>fetch(`https://geocoding-api.open-meteo.com/v1/search?count=5&language=en&name=${encodeURIComponent(q)}`).then(r=>r.json()),
+  weather:(lat,lon)=>fetch(`https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&current_weather=true`).then(r=>r.json())
+ };
+ const wIcon=document.getElementById('wicon');
+ const tempEl=document.getElementById('temp');
+ const descEl=document.getElementById('desc');
+ const locEl=document.getElementById('location');
+ const display=document.getElementById('display');
+ const sheet=document.getElementById('sheet');
+ const searchInput=document.getElementById('search');
+ const results=document.getElementById('results');
+ const openSearch=document.getElementById('openSearch');
+ const closeBtn=document.getElementById('close');
+ const locateBtn=document.getElementById('locate');
+ const codes={
+ 0:{i:'sunny',t:'Clear'},
+ 1:{i:'partly_cloudy_day',t:'Mostly Clear'},
+ 2:{i:'partly_cloudy_day',t:'Cloudy'},
+ 3:{i:'cloud',t:'Overcast'},
+ 45:{i:'foggy',t:'Fog'},
+ 48:{i:'foggy',t:'Fog'},
+ 51:{i:'rainy_light',t:'Drizzle'},
+ 53:{i:'rainy_light',t:'Drizzle'},
+ 55:{i:'rainy',t:'Rain'},
+ 61:{i:'rainy',t:'Rain'},
+ 63:{i:'rainy',t:'Rain'},
+ 65:{i:'rainy_heavy',t:'Rain'},
+ 80:{i:'rainy',t:'Showers'},
+ 95:{i:'thunderstorm',t:'Storm'},
+ 96:{i:'thunderstorm',t:'Storm'},
+ 99:{i:'thunderstorm',t:'Storm'}
+ };
+ function setHeight(){document.documentElement.style.setProperty('--vh',window.innerHeight*0.01+'px');}
+ window.addEventListener('resize',setHeight);setHeight();
+ function showWeather(data,place){
+  const cw=data.current_weather;
+  const c=codes[cw.weathercode]||{i:'question_mark',t:'Unknown'};
+  wIcon.textContent=c.i;
+  tempEl.textContent=Math.round(cw.temperature)+'°';
+  descEl.textContent=c.t;
+  locEl.textContent=place;
+  display.classList.remove('hide');
+  display.classList.add('show');
+ }
+ openSearch.onclick=()=>{sheet.classList.add('active');searchInput.focus();};
+ closeBtn.onclick=()=>{sheet.classList.remove('active');};
+ locateBtn.onclick=()=>{
+  navigator.geolocation.getCurrentPosition(pos=>{
+   api.weather(pos.coords.latitude,pos.coords.longitude).then(d=>showWeather(d,'Here'));
+  });
+ };
+ searchInput.oninput=()=>{
+  const q=searchInput.value.trim();
+  if(!q){results.innerHTML='';return;}
+  api.geo(q).then(d=>{
+   results.innerHTML='';
+   (d.results||[]).forEach(r=>{
+    const b=document.createElement('button');
+    b.textContent=`${r.name}, ${r.country_code}`;
+    b.onclick=()=>{
+     sheet.classList.remove('active');
+     api.weather(r.latitude,r.longitude).then(data=>showWeather(data,r.name));
+    };
+    results.appendChild(b);
+   });
+  });
+ };
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement single-file iOS-style weather app with bottom search and geolocation controls
- integrate Google Fonts and Material icons with preconnect hints
- add open-meteo API fetching, safe-area layout, and smooth animations

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1fd2f7ca88322b90b1fe4cbfe4857